### PR TITLE
Changes Made to HbaseDataSink,ReportWorker and KafkaDataSource

### DIFF
--- a/hbase/src/main/java/org/simplesql/hbase/HBaseDataSink.java
+++ b/hbase/src/main/java/org/simplesql/hbase/HBaseDataSink.java
@@ -99,7 +99,7 @@ public abstract class HBaseDataSink extends DefaultDataSink{
 	}
 	
 		
-	abstract Row createRow(KeyWriterReader kwr, Key key, Cell<?>[] data);
+	public abstract Row createRow(KeyWriterReader kwr, Key key, Cell<?>[] data);
 
 	/**
 	 * Utility method to return a TableFactory that will set auto flush to false for each table

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -21,8 +21,8 @@
 	<version>${project.version}</version>
 </dependency>
   <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-core</artifactId>
+      <groupId>kafka</groupId>
+      <artifactId>kafka</artifactId>
       <version>0.7.2</version>
       <scope>provided</scope>
     </dependency>

--- a/om/src/main/java/org/simplesql/om/aggregate/ReportWorker.java
+++ b/om/src/main/java/org/simplesql/om/aggregate/ReportWorker.java
@@ -28,13 +28,13 @@ public abstract class ReportWorker {
 		this.chunkSize = chunkSize;
 	}
 
-	abstract <T extends DataSink> DataSinkFactory<T> getDataSinkFactory();
+	public abstract <T extends DataSink> DataSinkFactory<T> getDataSinkFactory();
 
-	abstract DataSource getDataSource();
+	public abstract DataSource getDataSource();
 
-	abstract String getSchema();
+	public abstract String getSchema();
 
-	abstract String getSelect();
+	public abstract String getSelect();
 
 	public long stop() {
 		return (cn == null) ? 0L : cn.stopWait();


### PR DESCRIPTION
changed modifier of abstract  methods to public in HbaseDataSink and KafkaDataSource
In KafkaDataSource changed  
public TransformedIterator(Iterator<T> it, Transform<T> transform)
to 
public TransformedIterator(Iterator<MessageAndMetadata<T>> it, Transform<T> transform) 
to prevent ClassCastException
